### PR TITLE
feat: implement unread notifications badge functionality

### DIFF
--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -1,3 +1,63 @@
-export default defineBackground(() => {
-	console.log("background script loaded.");
+import { Backlog } from "backlog-js";
+import { browser } from "wxt/browser";
+import { getSpaces, watchSpaces } from "@/storages/spaces";
+
+const browserAction = browser.action ?? browser.browserAction;
+
+export default defineBackground({
+	main: () => {
+		browserAction.setBadgeTextColor({ color: "#ffffff" });
+
+		const setBadgeText = (count: number) => {
+			if (count <= 0) {
+				browserAction.setBadgeText({ text: undefined });
+				return;
+			}
+
+			const text = `${count}`;
+			browserAction.setBadgeText({ text });
+		};
+
+		const updateNotificationCount = async () => {
+			try {
+				const spaces = await getSpaces();
+				const countBySpaces = await Promise.all(
+					spaces.map(async ({ spaceDomain, apiKey }) => {
+						try {
+							const backlog = new Backlog({
+								apiKey: apiKey,
+								host: spaceDomain,
+							});
+							const { count } = await backlog.getNotificationsCount({
+								alreadyRead: false,
+								resourceAlreadyRead: false,
+							});
+							return count;
+						} catch {
+							return null;
+						}
+					}),
+				);
+				const hasError = countBySpaces.some((count) => count === null);
+				const totalCount = countBySpaces
+					.filter((count): count is number => count !== null)
+					.reduce((sum, count) => sum + count, 0);
+
+				setBadgeText(totalCount);
+				browserAction.setBadgeBackgroundColor({
+					color: hasError ? "#ffb219" : "#fe1aaf",
+				});
+			} catch {
+				browserAction.setBadgeText({ text: "!" });
+				browserAction.setBadgeBackgroundColor({ color: "#ffb219" });
+			}
+		};
+
+		browser.alarms.create({ periodInMinutes: 1 });
+		browser.alarms.onAlarm.addListener(updateNotificationCount);
+		watchSpaces(updateNotificationCount);
+
+		updateNotificationCount();
+	},
+	type: "module",
 });

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -1,5 +1,11 @@
 import { Backlog } from "backlog-js";
 import { browser } from "wxt/browser";
+import {
+	deleteNotificationCount,
+	getNotificationCounts,
+	updateNotificationCount,
+	watchNotificationCounts,
+} from "@/storages/notifications";
 import { getSpaces, watchSpaces } from "@/storages/spaces";
 
 const browserAction = browser.action ?? browser.browserAction;
@@ -8,42 +14,21 @@ export default defineBackground({
 	main: () => {
 		browserAction.setBadgeTextColor({ color: "#ffffff" });
 
-		const setBadgeText = (count: number) => {
-			if (count <= 0) {
-				browserAction.setBadgeText({ text: `${count}` });
-				return;
-			}
-
-			const text = `${count}`;
-			browserAction.setBadgeText({ text });
-		};
-
-		const updateNotificationCount = async () => {
+		const updateBadge = async () => {
 			try {
-				const spaces = await getSpaces();
-				const countBySpaces = await Promise.all(
-					spaces.map(async ({ spaceDomain, apiKey }) => {
-						try {
-							const backlog = new Backlog({
-								apiKey: apiKey,
-								host: spaceDomain,
-							});
-							const { count } = await backlog.getNotificationsCount({
-								alreadyRead: false,
-								resourceAlreadyRead: false,
-							});
-							return count;
-						} catch {
-							return null;
-						}
-					}),
+				const counts = await getNotificationCounts();
+				const hasError = Object.values(counts).some(
+					({ status }) => status === "failed",
 				);
-				const hasError = countBySpaces.some((count) => count === null);
-				const totalCount = countBySpaces
-					.filter((count): count is number => count !== null)
-					.reduce((sum, count) => sum + count, 0);
+				const totalCount = Object.values(counts)
+					.filter(({ status }) => status === "success")
+					.reduce((sum, { count }) => sum + count, 0);
 
-				setBadgeText(totalCount);
+				if (totalCount <= 0) {
+					browserAction.setBadgeText({ text: undefined });
+				} else {
+					browserAction.setBadgeText({ text: `${totalCount}` });
+				}
 
 				browserAction.setBadgeBackgroundColor({
 					color: hasError ? "#ffb219" : "#fe1aaf",
@@ -54,11 +39,52 @@ export default defineBackground({
 			}
 		};
 
-		browser.alarms.create({ periodInMinutes: 1 });
-		browser.alarms.onAlarm.addListener(updateNotificationCount);
-		watchSpaces(updateNotificationCount);
+		const fetchNotificationCounts = async () => {
+			const spaces = await getSpaces();
+			const currentCounts = await getNotificationCounts();
+			const spaceDomains = spaces.map(({ spaceDomain }) => spaceDomain);
 
-		updateNotificationCount();
+			// 存在しないスペースの通知キーを削除
+			await Promise.all(
+				Object.keys(currentCounts)
+					.filter((domain) => !spaceDomains.includes(domain))
+					.map((domain) => deleteNotificationCount(domain)),
+			);
+
+			// 各スペースの通知件数を取得・更新
+			await Promise.all(
+				spaces.map(async ({ spaceDomain, apiKey }) => {
+					try {
+						const backlog = new Backlog({
+							apiKey: apiKey,
+							host: spaceDomain,
+						});
+						const { count } = await backlog.getNotificationsCount({
+							alreadyRead: false,
+							resourceAlreadyRead: false,
+						});
+						await updateNotificationCount(spaceDomain, {
+							count,
+							status: "success",
+							updatedAt: Date.now(),
+						});
+					} catch {
+						await updateNotificationCount(spaceDomain, {
+							count: 0,
+							status: "failed",
+							updatedAt: Date.now(),
+						});
+					}
+				}),
+			);
+		};
+
+		browser.alarms.create({ periodInMinutes: 1 });
+		browser.alarms.onAlarm.addListener(fetchNotificationCounts);
+		watchSpaces(fetchNotificationCounts);
+		watchNotificationCounts(updateBadge);
+
+		fetchNotificationCounts();
 	},
 	type: "module",
 });

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -10,7 +10,7 @@ export default defineBackground({
 
 		const setBadgeText = (count: number) => {
 			if (count <= 0) {
-				browserAction.setBadgeText({ text: undefined });
+				browserAction.setBadgeText({ text: `${count}` });
 				return;
 			}
 
@@ -44,6 +44,7 @@ export default defineBackground({
 					.reduce((sum, count) => sum + count, 0);
 
 				setBadgeText(totalCount);
+
 				browserAction.setBadgeBackgroundColor({
 					color: hasError ? "#ffb219" : "#fe1aaf",
 				});

--- a/storages/notifications.ts
+++ b/storages/notifications.ts
@@ -1,0 +1,56 @@
+import { storage } from "#imports";
+import type {
+	NotificationCount,
+	NotificationCounts,
+} from "@/types/notification";
+
+const notifications = storage.defineItem<NotificationCounts>(
+	"local:notifications",
+	{
+		fallback: {},
+	},
+);
+
+/**
+ * 保存されているすべての通知件数を取得する
+ * @returns すべてのスペースの通知件数情報
+ */
+export const getNotificationCounts = () => notifications.getValue();
+
+/**
+ * 指定されたスペースの通知件数を更新する
+ * @param spaceDomain 更新対象のスペースドメイン
+ * @param notificationCount 通知件数情報
+ */
+export const updateNotificationCount = async (
+	spaceDomain: string,
+	notificationCount: NotificationCount,
+) => {
+	const currentCounts = await notifications.getValue();
+	currentCounts[spaceDomain] = notificationCount;
+	await notifications.setValue(currentCounts);
+};
+
+/**
+ * 指定されたスペースの通知件数を削除する
+ * @param spaceDomain 削除対象のスペースドメイン
+ */
+export const deleteNotificationCount = async (spaceDomain: string) => {
+	const currentCounts = await notifications.getValue();
+	delete currentCounts[spaceDomain];
+	await notifications.setValue(currentCounts);
+};
+
+/**
+ * 通知件数の変更を監視する
+ * @param callback 通知件数が変更された際に実行されるコールバック関数
+ * @returns 監視を停止するための関数
+ */
+export const watchNotificationCounts = (
+	callback: (
+		newCounts: NotificationCounts,
+		oldCounts: NotificationCounts,
+	) => void,
+) => {
+	return notifications.watch(callback);
+};

--- a/storages/spaces.ts
+++ b/storages/spaces.ts
@@ -63,3 +63,14 @@ export const deleteSpace = async (spaceDomain: string) => {
 	const updatedSpaces = currentSpaces.filter((_, i) => i !== index);
 	await spaces.setValue(updatedSpaces);
 };
+
+/**
+ * Backlogスペース配列の変更を監視する
+ * @param callback スペース配列が変更された際に実行されるコールバック関数
+ * @returns 監視を停止するための関数
+ */
+export const watchSpaces = (
+	callback: (newSpaces: BacklogSpace[], oldSpaces: BacklogSpace[]) => void,
+) => {
+	return spaces.watch(callback);
+};

--- a/types/notification.ts
+++ b/types/notification.ts
@@ -1,0 +1,20 @@
+/**
+ * 通知件数の取得状態
+ */
+export type NotificationStatus = "success" | "failed";
+
+/**
+ * スペースごとの通知件数情報
+ */
+export type NotificationCount = {
+	count: number;
+	updatedAt: number;
+	status: NotificationStatus;
+};
+
+/**
+ * すべてのスペースの通知件数を格納するオブジェクト
+ * キー: スペースドメイン名
+ * 値: 通知件数情報
+ */
+export type NotificationCounts = Record<string, NotificationCount>;

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
 		default_locale: "ja",
 		description: "__MSG_ext_description__",
 		name: "__MSG_ext_name__",
-		permissions: ["storage"],
+		permissions: ["alarms", "storage"],
 	},
 	modules: ["@wxt-dev/i18n/module", "@wxt-dev/auto-icons"],
 	vite: () => ({


### PR DESCRIPTION
## Summary
- Implement background script to fetch notification counts from Backlog API
- Add periodic update (1 minute interval) and space configuration monitoring  
- Create dedicated notification storage with status tracking
- Support multiple space notification aggregation with error handling
- Dynamic badge color based on API success/failure status

## Test plan
- [x] バッジが正常に表示されることを確認
- [x] 複数スペースの通知件数が正しく集計されることを確認
- [x] API エラー時にオレンジ色のバッジが表示されることを確認
- [x] スペース設定変更時に通知件数が再取得されることを確認
- [x] 1分間隔での自動更新が動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)