### PR TITLE
feat: add WXT_INITIAL_SPACES environment variable support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,14 @@ WXTフレームワーク、React、Tailwind CSSで構築されたブラウザ拡
 - `pnpm build` - 本番用に拡張機能をビルド
 - `pnpm postinstall` - Gitフックをインストールし、WXT環境を準備（`pnpm install`後に自動実行）
 
+### 開発向け環境変数
+
+- `WXT_INITIAL_SPACES` - 初期スペースを設定する環境変数
+  - フォーマット: `<spaceDomain>:<apiKey>,<spaceDomain>:<apiKey>,...`
+  - 例: `WXT_INITIAL_SPACES="example.backlog.com:your-api-key,another.backlog.jp:another-key"`
+  - 開発時にスペースを手動で追加する手間を省くために使用
+  - ストレージが空の場合のみ初期値として設定される
+
 ## コード品質とフォーマット
 
 - Biomeをリント・フォーマットに使用（lefthookのpre-commitフックで設定）

--- a/storages/spaces.ts
+++ b/storages/spaces.ts
@@ -1,8 +1,9 @@
 import { storage } from "#imports";
 import type { BacklogSpace } from "@/types/space";
+import { getInitialSpaces } from "@/utils/initialSpaces";
 
 const spaces = storage.defineItem<BacklogSpace[]>("local:spaces", {
-	fallback: [],
+	fallback: getInitialSpaces(),
 });
 
 /**

--- a/utils/initialSpaces.ts
+++ b/utils/initialSpaces.ts
@@ -1,0 +1,52 @@
+import type { BacklogSpace } from "@/types/space";
+
+/**
+ * 初期スペース環境変数を解析してBacklogSpaceの配列に変換する
+ * @param envValue 環境変数の値（<spaceDomain>:<apiKey>,<spaceDomain>:<apiKey>,...形式）
+ * @returns 解析されたBacklogSpaceの配列
+ */
+export const parseInitialSpaces = (envValue: string): BacklogSpace[] => {
+	if (!envValue) {
+		return [];
+	}
+
+	const spaceEntries = envValue.split(",");
+	const spaces: BacklogSpace[] = [];
+
+	for (const entry of spaceEntries) {
+		const trimmedEntry = entry.trim();
+		if (!trimmedEntry) {
+			continue;
+		}
+
+		const colonIndex = trimmedEntry.indexOf(":");
+		if (colonIndex === -1) {
+			console.warn(`Invalid initial space format: ${trimmedEntry}`);
+			continue;
+		}
+
+		const spaceDomain = trimmedEntry.slice(0, colonIndex).trim();
+		const apiKey = trimmedEntry.slice(colonIndex + 1).trim();
+
+		if (!spaceDomain || !apiKey) {
+			console.warn(`Invalid initial space format: ${trimmedEntry}`);
+			continue;
+		}
+
+		spaces.push({
+			apiKey,
+			spaceDomain,
+		});
+	}
+
+	return spaces;
+};
+
+/**
+ * WXT_INITIAL_SPACES環境変数から初期スペースを取得する
+ * @returns 初期スペースの配列
+ */
+export const getInitialSpaces = (): BacklogSpace[] => {
+	const envValue = import.meta.env.WXT_INITIAL_SPACES;
+	return parseInitialSpaces(envValue || "");
+};

--- a/utils/initialSpaces.ts
+++ b/utils/initialSpaces.ts
@@ -1,11 +1,11 @@
 import type { BacklogSpace } from "@/types/space";
 
 /**
- * 初期スペース環境変数を解析してBacklogSpaceの配列に変換する
- * @param envValue 環境変数の値（<spaceDomain>:<apiKey>,<spaceDomain>:<apiKey>,...形式）
+ * WXT_INITIAL_SPACES環境変数から初期スペースを取得・解析する
  * @returns 解析されたBacklogSpaceの配列
  */
-export const parseInitialSpaces = (envValue: string): BacklogSpace[] => {
+export const getInitialSpaces = (): BacklogSpace[] => {
+	const envValue = import.meta.env.WXT_INITIAL_SPACES;
 	if (!envValue) {
 		return [];
 	}
@@ -40,13 +40,4 @@ export const parseInitialSpaces = (envValue: string): BacklogSpace[] => {
 	}
 
 	return spaces;
-};
-
-/**
- * WXT_INITIAL_SPACES環境変数から初期スペースを取得する
- * @returns 初期スペースの配列
- */
-export const getInitialSpaces = (): BacklogSpace[] => {
-	const envValue = import.meta.env.WXT_INITIAL_SPACES;
-	return parseInitialSpaces(envValue || "");
 };

--- a/utils/initialSpaces.ts
+++ b/utils/initialSpaces.ts
@@ -6,7 +6,7 @@ import type { BacklogSpace } from "@/types/space";
  */
 export const getInitialSpaces = (): BacklogSpace[] => {
 	const envValue = import.meta.env.WXT_INITIAL_SPACES;
-	if (!envValue) return [];
+	if (typeof envValue !== "string") return [];
 
 	return envValue
 		.split(",")

--- a/utils/initialSpaces.ts
+++ b/utils/initialSpaces.ts
@@ -6,38 +6,14 @@ import type { BacklogSpace } from "@/types/space";
  */
 export const getInitialSpaces = (): BacklogSpace[] => {
 	const envValue = import.meta.env.WXT_INITIAL_SPACES;
-	if (!envValue) {
-		return [];
-	}
+	if (!envValue) return [];
 
-	const spaceEntries = envValue.split(",");
-	const spaces: BacklogSpace[] = [];
-
-	for (const entry of spaceEntries) {
-		const trimmedEntry = entry.trim();
-		if (!trimmedEntry) {
-			continue;
-		}
-
-		const colonIndex = trimmedEntry.indexOf(":");
-		if (colonIndex === -1) {
-			console.warn(`Invalid initial space format: ${trimmedEntry}`);
-			continue;
-		}
-
-		const spaceDomain = trimmedEntry.slice(0, colonIndex).trim();
-		const apiKey = trimmedEntry.slice(colonIndex + 1).trim();
-
-		if (!spaceDomain || !apiKey) {
-			console.warn(`Invalid initial space format: ${trimmedEntry}`);
-			continue;
-		}
-
-		spaces.push({
-			apiKey,
-			spaceDomain,
+	return envValue
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.includes(":"))
+		.map((entry) => {
+			const [spaceDomain, apiKey] = entry.split(":");
+			return { apiKey, spaceDomain };
 		});
-	}
-
-	return spaces;
 };


### PR DESCRIPTION
## Summary
- WXT_INITIAL_SPACES環境変数により初期スペースを自動設定する開発向け機能を追加
- `<spaceDomain>:<apiKey>,<spaceDomain>:<apiKey>,...` 形式で複数スペースをサポート
- ストレージのfallbackとして動作し、既存データには影響しない

## Test plan
- [x] 環境変数なしでの動作確認（従来通り空の配列）
- [x] 環境変数設定時に初期スペースが正しく登録されること
- [x] 不正な形式の環境変数でもエラーにならないこと
- [x] 既存のスペースデータがある場合は環境変数が無視されること

## 実装内容
- `utils/initialSpaces.ts`: 環境変数解析機能
- `storages/spaces.ts`: fallbackでの初期スペース設定
- `CLAUDE.md`: 開発向け機能のドキュメント追加

🤖 Generated with [Claude Code](https://claude.ai/code)