### PR TITLE
feat: add NotificationItem and ProjectItem Storybook stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,6 @@
 import type { StorybookConfig } from "@storybook/react-vite";
+import tailwindcss from "@tailwindcss/vite";
+import { mergeConfig } from "vite";
 
 const config: StorybookConfig = {
 	addons: [
@@ -18,6 +20,14 @@ const config: StorybookConfig = {
 	typescript: {
 		check: true,
 		reactDocgen: "react-docgen-typescript",
+	},
+	async viteFinal(config) {
+		return mergeConfig(config, {
+			plugins: [
+				// biome-ignore lint/suspicious/noExplicitAny: TailwindCSS v4 は Vite 6 に未対応
+				tailwindcss() as any,
+			],
+		});
 	},
 };
 

--- a/components/NotificationItem/NotificationItem.stories.tsx
+++ b/components/NotificationItem/NotificationItem.stories.tsx
@@ -1,0 +1,257 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Entity } from "backlog-js";
+import { NotificationItem } from "./index";
+
+/**
+ * 通知アイテムコンポーネントのStorybook定義
+ */
+const meta = {
+	argTypes: {
+		notification: {
+			description: "表示する通知データ",
+		},
+	},
+	component: NotificationItem,
+	parameters: {
+		layout: "centered",
+	},
+	tags: ["autodocs"],
+	title: "Components/NotificationItem",
+} satisfies Meta<typeof NotificationItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 基本的な通知データのモック
+const baseNotification: Entity.Notification.Notification = {
+	alreadyRead: false,
+	comment: null,
+	created: "2024-01-01T12:00:00Z",
+	id: 1,
+	issue: {
+		actualHours: null,
+		assignee: {
+			id: 1,
+			lang: "ja",
+			mailAddress: "assignee@example.com",
+			name: "担当者",
+			roleType: 1,
+			userId: "user1",
+		},
+		attachments: [],
+		category: [],
+		created: "2024-01-01T10:00:00Z",
+		createdUser: {
+			id: 2,
+			lang: "ja",
+			mailAddress: "creator@example.com",
+			name: "作成者",
+			roleType: 1,
+			userId: "creator",
+		},
+		customFields: [],
+		description: "これはサンプルの課題です",
+		dueDate: null,
+		estimatedHours: null,
+		id: 1,
+		issueKey: "TEST-1",
+		issueType: {
+			color: "#7ea800",
+			displayOrder: 0,
+			id: 1,
+			name: "タスク",
+			projectId: 1,
+		},
+		keyId: 1,
+		milestone: [],
+		parentIssueId: null,
+		priority: {
+			id: 3,
+			name: "中",
+		},
+		projectId: 1,
+		resolution: null,
+		sharedFiles: [],
+		stars: [],
+		startDate: null,
+		status: {
+			color: "#ed8077",
+			displayOrder: 1,
+			id: 1,
+			name: "未対応",
+			projectId: 1,
+		},
+		summary: "サンプル課題",
+		updated: "2024-01-01T11:00:00Z",
+		updatedUser: {
+			id: 2,
+			lang: "ja",
+			mailAddress: "updater@example.com",
+			name: "更新者",
+			roleType: 1,
+			userId: "updater",
+		},
+		versions: [],
+	},
+	project: {
+		archived: false,
+		chartEnabled: true,
+		displayOrder: 0,
+		id: 1,
+		name: "テストプロジェクト",
+		projectKey: "TEST",
+		projectLeaderCanEditProjectLeader: true,
+		subtaskingEnabled: true,
+		textFormattingRule: "markdown",
+		useDevAttributes: false,
+		useFileSharing: true,
+		useResolvedForChart: true,
+		useWiki: true,
+		useWikiTreeView: true,
+	},
+	pullRequest: null,
+	pullRequestComment: null,
+	reason: 1,
+	resourceAlreadyRead: false,
+	sender: {
+		id: 2,
+		lang: "ja",
+		mailAddress: "sender@example.com",
+		name: "送信者",
+		roleType: 1,
+		userId: "sender1",
+	},
+	user: {
+		id: 1,
+		lang: "ja",
+		mailAddress: "user1@example.com",
+		name: "ユーザー1",
+		roleType: 1,
+		userId: "user1",
+	},
+};
+
+/**
+ * 担当者に設定された通知
+ */
+export const AssignedNotification: Story = {
+	args: {
+		notification: {
+			...baseNotification,
+			reason: 1,
+		},
+	},
+};
+
+/**
+ * コメントされた通知
+ */
+export const CommentedNotification: Story = {
+	args: {
+		notification: {
+			...baseNotification,
+			comment: {
+				changeLog: [],
+				content: "コメントの内容です",
+				created: "2024-01-01T12:00:00Z",
+				createdUser: {
+					id: 2,
+					lang: "ja",
+					mailAddress: "commenter@example.com",
+					name: "コメント者",
+					roleType: 1,
+					userId: "commenter",
+				},
+				id: 1,
+				notifications: [],
+				stars: [],
+				updated: "2024-01-01T12:00:00Z",
+			},
+			reason: 2,
+		},
+	},
+};
+
+/**
+ * 課題が追加された通知
+ */
+export const IssueAddedNotification: Story = {
+	args: {
+		notification: {
+			...baseNotification,
+			reason: 3,
+		},
+	},
+};
+
+/**
+ * 課題が更新された通知
+ */
+export const IssueUpdatedNotification: Story = {
+	args: {
+		notification: {
+			...baseNotification,
+			reason: 4,
+		},
+	},
+};
+
+/**
+ * ファイルが添付された通知
+ */
+export const FileAttachedNotification: Story = {
+	args: {
+		notification: {
+			...baseNotification,
+			reason: 5,
+		},
+	},
+};
+
+/**
+ * プロジェクトに追加された通知
+ */
+export const ProjectAddedNotification: Story = {
+	args: {
+		notification: {
+			...baseNotification,
+			reason: 6,
+		},
+	},
+};
+
+/**
+ * プルリクエストが追加された通知
+ */
+export const PullRequestAddedNotification: Story = {
+	args: {
+		notification: {
+			...baseNotification,
+			reason: 12,
+		},
+	},
+};
+
+/**
+ * プルリクエストが更新された通知
+ */
+export const PullRequestUpdatedNotification: Story = {
+	args: {
+		notification: {
+			...baseNotification,
+			reason: 13,
+		},
+	},
+};
+
+/**
+ * 不明な理由の通知
+ */
+export const UnknownReasonNotification: Story = {
+	args: {
+		notification: {
+			...baseNotification,
+			reason: 999,
+		},
+	},
+};

--- a/components/NotificationItem/NotificationItem.stories.tsx
+++ b/components/NotificationItem/NotificationItem.stories.tsx
@@ -6,17 +6,8 @@ import { NotificationItem } from "./index";
  * 通知アイテムコンポーネントのStorybook定義
  */
 const meta = {
-	argTypes: {
-		notification: {
-			description: "表示する通知データ",
-		},
-	},
 	component: NotificationItem,
-	parameters: {
-		layout: "centered",
-	},
 	tags: ["autodocs"],
-	title: "Components/NotificationItem",
 } satisfies Meta<typeof NotificationItem>;
 
 export default meta;

--- a/components/NotificationItem/index.tsx
+++ b/components/NotificationItem/index.tsx
@@ -40,8 +40,6 @@ type Props = {
 export const NotificationItem: React.FC<Props> = ({ notification }) => {
 	const reasonText = getReasonText(notification.reason);
 
-	notification.project.projectKey;
-
 	return (
 		<div className="grid grid-cols-[auto_1fr_auto] gap-3 p-4">
 			<img

--- a/components/NotificationItem/index.tsx
+++ b/components/NotificationItem/index.tsx
@@ -1,0 +1,84 @@
+import type { Entity } from "backlog-js";
+
+/** ステータスメッセージのテキストを取得 */
+const getReasonText = (reason: number): [string, string, string] => {
+	switch (reason) {
+		case 1:
+		case 10:
+			return ["", "担当者", "に設定しました。"];
+		case 2:
+		case 11:
+			return ["", "コメント", "しました。"];
+		case 3:
+			return ["課題を", "追加", "しました。"];
+		case 4:
+			return ["課題を", "更新", "しました。"];
+		case 5:
+			return ["ファイルを", "添付", "しました。"];
+		case 6:
+			return ["プロジェクトに", "追加", "しました。"];
+		case 12:
+			return ["プルリクエストを", "追加", "しました。"];
+		case 13:
+			return ["プルリクエストを", "更新", "しました。"];
+		default:
+			return ["", "お知らせ", "しました。"];
+	}
+};
+
+type Props = {
+	notification: Entity.Notification.Notification;
+};
+
+export const NotificationItem: React.FC<Props> = ({ notification }) => {
+	const reasonText = getReasonText(notification.reason);
+
+	return (
+		<div className="grid grid-cols-[auto,1fr,auto] gap-3 p-4">
+			<img
+				alt=""
+				className="h-10 w-10 rounded-full object-cover"
+				src={"https://placehold.jp/320x320.png"}
+			/>
+			<div className="grid gap-1">
+				<p className="line-clamp-1 text-gray-500 text-xs">
+					{notification.sender.name} さんが{reasonText[0]}{" "}
+					<span
+						className={
+							[6, 10, 11, 12, 13].includes(notification.reason)
+								? "text-pink-600"
+								: "text-brand-600"
+						}
+					>
+						{reasonText[1]}
+					</span>{" "}
+					{reasonText[2]}
+				</p>
+				{/* <p className="line-clamp-1 text-sm">
+          {notification.comment?.content ?? `${projectKey}_${issueKey} ${issueSummary}`}
+        </p>
+        {commentContent && (
+          <p className="line-clamp-1 text-gray-500 text-xs">
+            {projectKey}_{issueKey} {issueSummary}
+          </p>
+        )}
+      </div>
+      <div className="flex flex-col items-end gap-1">
+        <time className="text-gray-500 text-xs" dateTime={created}>
+          {timeAgo.format(new Date(created), "round-minute")}
+        </time>
+        <p
+          className={clsx(
+            "line-clamp-1 max-w-32 rounded-full px-2 text-center text-xs leading-relaxed",
+            tinycolor(statusColor).getLuminance() < 0.5
+              ? "text-white"
+              : "text-black",
+          )}
+          style={{ backgroundColor: statusColor }}
+        >
+          {statusName}
+        </p> */}
+			</div>
+		</div>
+	);
+};

--- a/components/NotificationItem/index.tsx
+++ b/components/NotificationItem/index.tsx
@@ -1,4 +1,11 @@
 import type { Entity } from "backlog-js";
+import { clsx } from "clsx";
+import TimeAgo from "javascript-time-ago";
+import ja from "javascript-time-ago/locale/ja";
+import tinycolor from "tinycolor2";
+
+TimeAgo.addLocale(ja);
+const timeAgo = new TimeAgo("ja-JP");
 
 /** ステータスメッセージのテキストを取得 */
 const getReasonText = (reason: number): [string, string, string] => {
@@ -33,8 +40,10 @@ type Props = {
 export const NotificationItem: React.FC<Props> = ({ notification }) => {
 	const reasonText = getReasonText(notification.reason);
 
+	notification.project.projectKey;
+
 	return (
-		<div className="grid grid-cols-[auto,1fr,auto] gap-3 p-4">
+		<div className="grid grid-cols-[auto_1fr_auto] gap-3 p-4">
 			<img
 				alt=""
 				className="h-10 w-10 rounded-full object-cover"
@@ -54,30 +63,32 @@ export const NotificationItem: React.FC<Props> = ({ notification }) => {
 					</span>{" "}
 					{reasonText[2]}
 				</p>
-				{/* <p className="line-clamp-1 text-sm">
-          {notification.comment?.content ?? `${projectKey}_${issueKey} ${issueSummary}`}
-        </p>
-        {commentContent && (
-          <p className="line-clamp-1 text-gray-500 text-xs">
-            {projectKey}_{issueKey} {issueSummary}
-          </p>
-        )}
-      </div>
-      <div className="flex flex-col items-end gap-1">
-        <time className="text-gray-500 text-xs" dateTime={created}>
-          {timeAgo.format(new Date(created), "round-minute")}
-        </time>
-        <p
-          className={clsx(
-            "line-clamp-1 max-w-32 rounded-full px-2 text-center text-xs leading-relaxed",
-            tinycolor(statusColor).getLuminance() < 0.5
-              ? "text-white"
-              : "text-black",
-          )}
-          style={{ backgroundColor: statusColor }}
-        >
-          {statusName}
-        </p> */}
+				<p className="line-clamp-1 text-sm">
+					{notification.comment?.content ??
+						`${notification.project.projectKey}_${notification.issue?.issueKey} ${notification.issue?.summary}`}
+				</p>
+				{notification.comment?.content && (
+					<p className="line-clamp-1 text-gray-500 text-xs">
+						{notification.comment?.content ??
+							`${notification.project.projectKey}_${notification.issue?.issueKey} ${notification.issue?.summary}`}
+					</p>
+				)}
+			</div>
+			<div className="flex flex-col items-end gap-1">
+				<time className="text-gray-500 text-xs" dateTime={notification.created}>
+					{timeAgo.format(new Date(notification.created), "round-minute")}
+				</time>
+				<p
+					className={clsx(
+						"line-clamp-1 max-w-32 rounded-full px-2 text-center text-xs leading-relaxed",
+						tinycolor(notification.issue?.status.color).getLuminance() < 0.5
+							? "text-white"
+							: "text-black",
+					)}
+					style={{ backgroundColor: notification.issue?.status.color }}
+				>
+					{notification.issue?.status.name}
+				</p>
 			</div>
 		</div>
 	);

--- a/components/ProjectItem/ProjectItem.stories.tsx
+++ b/components/ProjectItem/ProjectItem.stories.tsx
@@ -1,0 +1,169 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Entity } from "backlog-js";
+import { ProjectItem } from "./index";
+
+/**
+ * プロジェクトアイテムコンポーネントのStorybook定義
+ */
+const meta = {
+	component: ProjectItem,
+	tags: ["autodocs"],
+} satisfies Meta<typeof ProjectItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 基本的なプロジェクトデータのモック
+const baseProject: Entity.Project.Project = {
+	archived: false,
+	chartEnabled: true,
+	displayOrder: 0,
+	id: 1,
+	name: "サンプルプロジェクト",
+	projectKey: "SAMPLE",
+	projectLeaderCanEditProjectLeader: true,
+	subtaskingEnabled: true,
+	textFormattingRule: "markdown",
+	useDevAttributes: false,
+	useFileSharing: true,
+	useGit: false,
+	useResolvedForChart: true,
+	useSubversion: false,
+	useWiki: true,
+	useWikiTreeView: true,
+};
+
+/**
+ * 基本的なプロジェクト（全機能有効）
+ */
+export const DefaultProject: Story = {
+	args: {
+		project: {
+			...baseProject,
+			useFileSharing: true,
+			useGit: true,
+			useSubversion: true,
+			useWiki: true,
+		},
+	},
+};
+
+/**
+ * 最小構成のプロジェクト（Wiki、ファイル共有、Git、Subversion無効）
+ */
+export const MinimalProject: Story = {
+	args: {
+		project: {
+			...baseProject,
+			name: "最小構成プロジェクト",
+			projectKey: "MIN",
+			useFileSharing: false,
+			useGit: false,
+			useSubversion: false,
+			useWiki: false,
+		},
+	},
+};
+
+/**
+ * Wiki有効プロジェクト
+ */
+export const WikiEnabledProject: Story = {
+	args: {
+		project: {
+			...baseProject,
+			name: "Wiki使用プロジェクト",
+			projectKey: "WIKI",
+			useFileSharing: false,
+			useGit: false,
+			useSubversion: false,
+			useWiki: true,
+		},
+	},
+};
+
+/**
+ * ファイル共有有効プロジェクト
+ */
+export const FileSharingEnabledProject: Story = {
+	args: {
+		project: {
+			...baseProject,
+			name: "ファイル共有プロジェクト",
+			projectKey: "FILE",
+			useFileSharing: true,
+			useGit: false,
+			useSubversion: false,
+			useWiki: false,
+		},
+	},
+};
+
+/**
+ * Git有効プロジェクト
+ */
+export const GitEnabledProject: Story = {
+	args: {
+		project: {
+			...baseProject,
+			name: "Git使用プロジェクト",
+			projectKey: "GIT",
+			useFileSharing: false,
+			useGit: true,
+			useSubversion: false,
+			useWiki: false,
+		},
+	},
+};
+
+/**
+ * Subversion有効プロジェクト
+ */
+export const SubversionEnabledProject: Story = {
+	args: {
+		project: {
+			...baseProject,
+			name: "SVN使用プロジェクト",
+			projectKey: "SVN",
+			useFileSharing: false,
+			useGit: false,
+			useSubversion: true,
+			useWiki: false,
+		},
+	},
+};
+
+/**
+ * 長いプロジェクト名
+ */
+export const LongNameProject: Story = {
+	args: {
+		project: {
+			...baseProject,
+			name: "非常に長いプロジェクト名を持つプロジェクトのサンプルケース",
+			projectKey: "LONG_NAME_PROJ",
+			useFileSharing: true,
+			useGit: true,
+			useSubversion: false,
+			useWiki: true,
+		},
+	},
+};
+
+/**
+ * アーカイブ済みプロジェクト
+ */
+export const ArchivedProject: Story = {
+	args: {
+		project: {
+			...baseProject,
+			archived: true,
+			name: "アーカイブ済みプロジェクト",
+			projectKey: "ARCH",
+			useFileSharing: true,
+			useGit: false,
+			useSubversion: false,
+			useWiki: true,
+		},
+	},
+};

--- a/components/ProjectItem/index.tsx
+++ b/components/ProjectItem/index.tsx
@@ -1,0 +1,48 @@
+import type { Entity } from "backlog-js";
+
+type Props = {
+	project: Entity.Project.Project;
+};
+
+export const ProjectItem: React.FC<Props> = ({ project }) => {
+	const navItems = [
+		{ action: "add", enabled: true, label: "課題の追加" },
+		{ action: "find", enabled: true, label: "課題" },
+		{ action: "wiki", enabled: project.useWiki, label: "Wiki" },
+		{ action: "file", enabled: project.useFileSharing, label: "ファイル" },
+		{
+			action: "subversion",
+			enabled: project.useSubversion,
+			label: "Subversion",
+		},
+		{ action: "git", enabled: project.useGit, label: "Git" },
+	].filter(({ enabled }) => enabled);
+
+	return (
+		<button
+			className="grid grid-cols-[auto_1fr] gap-y-1 p-4 hover:bg-yellow-50"
+			type="button"
+		>
+			<img
+				alt=""
+				className="h-7 w-7 object-cover"
+				src="https://placehold.jp/320x320.png"
+			/>
+			<span className="flex items-end gap-1 self-center px-3 text-sm leading-none">
+				<span className="line-clamp-1">{project.name}</span>
+				<span className="text-2xs">({project.projectKey})</span>
+			</span>
+			<span className="col-start-2 flex flex-wrap">
+				{navItems.map(({ action, label }) => (
+					<button
+						className="border-gray-300 border-r px-3 text-gray-500 text-xs leading-tight last:border-0 hover:text-black hover:underline"
+						key={action}
+						type="button"
+					>
+						{label}
+					</button>
+				))}
+			</span>
+		</button>
+	);
+};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"semantic-release": "^24.2.5",
 		"storybook": "^9.0.12",
 		"tailwindcss": "^4.1.10",
+		"vite": "^6.3.5",
 		"wxt": "^0.20.7"
 	},
 	"name": "backlog-antenna",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
 		"@tanstack/react-router": "^1.121.21",
 		"@tanstack/react-virtual": "^3.13.10",
 		"backlog-js": "^0.13.5",
+		"clsx": "^2.1.1",
+		"javascript-time-ago": "^2.5.11",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
+		"tinycolor2": "^1.6.0",
 		"valibot": "^1.1.0"
 	},
 	"devDependencies": {
@@ -27,6 +30,7 @@
 		"@tsconfig/vite-react": "^6.3.6",
 		"@types/react": "^19.1.8",
 		"@types/react-dom": "^19.1.6",
+		"@types/tinycolor2": "^1.4.6",
 		"@wxt-dev/auto-icons": "^1.0.2",
 		"@wxt-dev/i18n": "^0.2.4",
 		"lefthook": "^1.11.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.10
         version: 4.1.10
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)
       wxt:
         specifier: ^0.20.7
         version: 0.20.7(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.35.0)(tsx@4.20.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,12 +32,21 @@ importers:
       backlog-js:
         specifier: ^0.13.5
         version: 0.13.5
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      javascript-time-ago:
+        specifier: ^2.5.11
+        version: 2.5.11
       react:
         specifier: ^19.1.0
         version: 19.1.0
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      tinycolor2:
+        specifier: ^1.6.0
+        version: 1.6.0
       valibot:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.8.2)
@@ -84,6 +93,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
+      '@types/tinycolor2':
+        specifier: ^1.4.6
+        version: 1.4.6
       '@wxt-dev/auto-icons':
         specifier: ^1.0.2
         version: 1.0.2(wxt@0.20.7(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.35.0)(tsx@4.20.3))
@@ -1346,6 +1358,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/tinycolor2@1.4.6':
+    resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -2626,6 +2641,9 @@ packages:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
 
+  javascript-time-ago@2.5.11:
+    resolution: {integrity: sha512-Zeyf5R7oM1fSMW9zsU3YgAYwE0bimEeF54Udn2ixGd8PUwu+z1Yc5t4Y8YScJDMHD6uCx6giLt3VJR5K4CMwbg==}
+
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
@@ -3512,6 +3530,9 @@ packages:
     resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
     engines: {node: '>=12'}
 
+  relative-time-format@1.1.6:
+    resolution: {integrity: sha512-aCv3juQw4hT1/P/OrVltKWLlp15eW1GRcwP1XdxHrPdZE9MtgqFpegjnTjLhi2m2WI9MT/hQQtE+tjEWG1hgkQ==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -3887,6 +3908,9 @@ packages:
 
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -5505,6 +5529,8 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/tinycolor2@1.4.6': {}
+
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 22.13.10
@@ -6768,6 +6794,10 @@ snapshots:
 
   java-properties@1.0.2: {}
 
+  javascript-time-ago@2.5.11:
+    dependencies:
+      relative-time-format: 1.1.6
+
   jiti@2.4.2: {}
 
   js-tokens@4.0.0: {}
@@ -7582,6 +7612,8 @@ snapshots:
     dependencies:
       rc: 1.2.8
 
+  relative-time-format@1.1.6: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -8019,6 +8051,8 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tiny-warning@1.0.3: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 


### PR DESCRIPTION
## Summary

- NotificationItemコンポーネントのStorybookストーリーを作成
- ProjectItemコンポーネントのStorybookストーリーを作成  
- Storybook設定にTailwind CSS Viteプラグインを追加
- 必要な依存関係（javascript-time-ago、tinycolor2、clsx）を追加

## Changes

### NotificationItem Stories
- 8つの通知タイプ（担当者設定、コメント、課題追加/更新、ファイル添付、プロジェクト追加、プルリクエスト追加/更新、不明な理由）のストーリーを定義
- 日時表示とステータス色表示機能を実装

### ProjectItem Stories  
- 8つのプロジェクト設定パターン（全機能有効、最小構成、各機能個別有効、長いプロジェクト名、アーカイブ済み）のストーリーを定義
- 機能の有無による表示変化を確認可能

### Storybook Configuration
- `.storybook/main.ts`にTailwind CSS Viteプラグインを追加
- 静的importを使用してVite mergeConfig を読み込み

## Test plan

- [x] Storybookサーバーを起動して各ストーリーが正常に表示されることを確認
- [x] Tailwind CSSスタイルが適用されることを確認
- [x] 各コンポーネントの異なるプロパティ組み合わせが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)