### PR TITLE
fix: update component props to use individual props instead of object props

### DIFF
--- a/components/NotificationItem/NotificationItem.stories.tsx
+++ b/components/NotificationItem/NotificationItem.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import type { Entity } from "backlog-js";
 import { NotificationItem } from "./index";
 
 /**
@@ -13,113 +12,17 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// 基本的な通知データのモック
-const baseNotification: Entity.Notification.Notification = {
-	alreadyRead: false,
-	comment: null,
+// 基本的な通知データ
+const baseArgs = {
+	commentContent: undefined,
 	created: "2024-01-01T12:00:00Z",
-	id: 1,
-	issue: {
-		actualHours: null,
-		assignee: {
-			id: 1,
-			lang: "ja",
-			mailAddress: "assignee@example.com",
-			name: "担当者",
-			roleType: 1,
-			userId: "user1",
-		},
-		attachments: [],
-		category: [],
-		created: "2024-01-01T10:00:00Z",
-		createdUser: {
-			id: 2,
-			lang: "ja",
-			mailAddress: "creator@example.com",
-			name: "作成者",
-			roleType: 1,
-			userId: "creator",
-		},
-		customFields: [],
-		description: "これはサンプルの課題です",
-		dueDate: null,
-		estimatedHours: null,
-		id: 1,
-		issueKey: "TEST-1",
-		issueType: {
-			color: "#7ea800",
-			displayOrder: 0,
-			id: 1,
-			name: "タスク",
-			projectId: 1,
-		},
-		keyId: 1,
-		milestone: [],
-		parentIssueId: null,
-		priority: {
-			id: 3,
-			name: "中",
-		},
-		projectId: 1,
-		resolution: null,
-		sharedFiles: [],
-		stars: [],
-		startDate: null,
-		status: {
-			color: "#ed8077",
-			displayOrder: 1,
-			id: 1,
-			name: "未対応",
-			projectId: 1,
-		},
-		summary: "サンプル課題",
-		updated: "2024-01-01T11:00:00Z",
-		updatedUser: {
-			id: 2,
-			lang: "ja",
-			mailAddress: "updater@example.com",
-			name: "更新者",
-			roleType: 1,
-			userId: "updater",
-		},
-		versions: [],
-	},
-	project: {
-		archived: false,
-		chartEnabled: true,
-		displayOrder: 0,
-		id: 1,
-		name: "テストプロジェクト",
-		projectKey: "TEST",
-		projectLeaderCanEditProjectLeader: true,
-		subtaskingEnabled: true,
-		textFormattingRule: "markdown",
-		useDevAttributes: false,
-		useFileSharing: true,
-		useResolvedForChart: true,
-		useWiki: true,
-		useWikiTreeView: true,
-	},
-	pullRequest: null,
-	pullRequestComment: null,
+	issueKey: "TEST-1",
+	issueSummary: "サンプル課題",
+	projectKey: "TEST",
 	reason: 1,
-	resourceAlreadyRead: false,
-	sender: {
-		id: 2,
-		lang: "ja",
-		mailAddress: "sender@example.com",
-		name: "送信者",
-		roleType: 1,
-		userId: "sender1",
-	},
-	user: {
-		id: 1,
-		lang: "ja",
-		mailAddress: "user1@example.com",
-		name: "ユーザー1",
-		roleType: 1,
-		userId: "user1",
-	},
+	senderName: "送信者",
+	statusColor: "#ed8077",
+	statusName: "未対応",
 };
 
 /**
@@ -127,10 +30,8 @@ const baseNotification: Entity.Notification.Notification = {
  */
 export const AssignedNotification: Story = {
 	args: {
-		notification: {
-			...baseNotification,
-			reason: 1,
-		},
+		...baseArgs,
+		reason: 1,
 	},
 };
 
@@ -139,27 +40,9 @@ export const AssignedNotification: Story = {
  */
 export const CommentedNotification: Story = {
 	args: {
-		notification: {
-			...baseNotification,
-			comment: {
-				changeLog: [],
-				content: "コメントの内容です",
-				created: "2024-01-01T12:00:00Z",
-				createdUser: {
-					id: 2,
-					lang: "ja",
-					mailAddress: "commenter@example.com",
-					name: "コメント者",
-					roleType: 1,
-					userId: "commenter",
-				},
-				id: 1,
-				notifications: [],
-				stars: [],
-				updated: "2024-01-01T12:00:00Z",
-			},
-			reason: 2,
-		},
+		...baseArgs,
+		commentContent: "コメントの内容です",
+		reason: 2,
 	},
 };
 
@@ -168,10 +51,8 @@ export const CommentedNotification: Story = {
  */
 export const IssueAddedNotification: Story = {
 	args: {
-		notification: {
-			...baseNotification,
-			reason: 3,
-		},
+		...baseArgs,
+		reason: 3,
 	},
 };
 
@@ -180,10 +61,8 @@ export const IssueAddedNotification: Story = {
  */
 export const IssueUpdatedNotification: Story = {
 	args: {
-		notification: {
-			...baseNotification,
-			reason: 4,
-		},
+		...baseArgs,
+		reason: 4,
 	},
 };
 
@@ -192,10 +71,8 @@ export const IssueUpdatedNotification: Story = {
  */
 export const FileAttachedNotification: Story = {
 	args: {
-		notification: {
-			...baseNotification,
-			reason: 5,
-		},
+		...baseArgs,
+		reason: 5,
 	},
 };
 
@@ -204,10 +81,8 @@ export const FileAttachedNotification: Story = {
  */
 export const ProjectAddedNotification: Story = {
 	args: {
-		notification: {
-			...baseNotification,
-			reason: 6,
-		},
+		...baseArgs,
+		reason: 6,
 	},
 };
 
@@ -216,10 +91,8 @@ export const ProjectAddedNotification: Story = {
  */
 export const PullRequestAddedNotification: Story = {
 	args: {
-		notification: {
-			...baseNotification,
-			reason: 12,
-		},
+		...baseArgs,
+		reason: 12,
 	},
 };
 
@@ -228,10 +101,8 @@ export const PullRequestAddedNotification: Story = {
  */
 export const PullRequestUpdatedNotification: Story = {
 	args: {
-		notification: {
-			...baseNotification,
-			reason: 13,
-		},
+		...baseArgs,
+		reason: 13,
 	},
 };
 
@@ -240,9 +111,7 @@ export const PullRequestUpdatedNotification: Story = {
  */
 export const UnknownReasonNotification: Story = {
 	args: {
-		notification: {
-			...baseNotification,
-			reason: 999,
-		},
+		...baseArgs,
+		reason: 999,
 	},
 };

--- a/components/NotificationItem/index.tsx
+++ b/components/NotificationItem/index.tsx
@@ -1,4 +1,3 @@
-import type { Entity } from "backlog-js";
 import { clsx } from "clsx";
 import TimeAgo from "javascript-time-ago";
 import ja from "javascript-time-ago/locale/ja";
@@ -34,11 +33,33 @@ const getReasonText = (reason: number): [string, string, string] => {
 };
 
 type Props = {
-	notification: Entity.Notification.Notification;
+	alreadyRead: boolean;
+	reason: number;
+	projectKey: string;
+	issueKey: string;
+	issueSummary: string;
+	statusName: string;
+	statusColor: string;
+	commentContent: string | undefined;
+	senderUserId: string;
+	senderName: string;
+	created: string;
 };
 
-export const NotificationItem: React.FC<Props> = ({ notification }) => {
-	const reasonText = getReasonText(notification.reason);
+export const NotificationItem: React.FC<Props> = ({
+	alreadyRead,
+	reason,
+	projectKey,
+	issueKey,
+	issueSummary,
+	statusName,
+	statusColor,
+	commentContent,
+	senderUserId,
+	senderName,
+	created,
+}) => {
+	const reasonText = getReasonText(reason);
 
 	return (
 		<div className="grid grid-cols-[auto_1fr_auto] gap-3 p-4">
@@ -49,10 +70,10 @@ export const NotificationItem: React.FC<Props> = ({ notification }) => {
 			/>
 			<div className="grid gap-1">
 				<p className="line-clamp-1 text-gray-500 text-xs">
-					{notification.sender.name} さんが{reasonText[0]}{" "}
+					{senderName} さんが{reasonText[0]}{" "}
 					<span
 						className={
-							[6, 10, 11, 12, 13].includes(notification.reason)
+							[6, 10, 11, 12, 13].includes(reason)
 								? "text-pink-600"
 								: "text-brand-600"
 						}
@@ -62,30 +83,28 @@ export const NotificationItem: React.FC<Props> = ({ notification }) => {
 					{reasonText[2]}
 				</p>
 				<p className="line-clamp-1 text-sm">
-					{notification.comment?.content ??
-						`${notification.project.projectKey}_${notification.issue?.issueKey} ${notification.issue?.summary}`}
+					{commentContent ?? `${projectKey}_${issueKey} ${issueSummary}`}
 				</p>
-				{notification.comment?.content && (
+				{commentContent && (
 					<p className="line-clamp-1 text-gray-500 text-xs">
-						{notification.comment?.content ??
-							`${notification.project.projectKey}_${notification.issue?.issueKey} ${notification.issue?.summary}`}
+						{commentContent ?? `${projectKey}_${issueKey} ${issueSummary}`}
 					</p>
 				)}
 			</div>
 			<div className="flex flex-col items-end gap-1">
-				<time className="text-gray-500 text-xs" dateTime={notification.created}>
-					{timeAgo.format(new Date(notification.created), "round-minute")}
+				<time className="text-gray-500 text-xs" dateTime={created}>
+					{timeAgo.format(new Date(created), "round-minute")}
 				</time>
 				<p
 					className={clsx(
 						"line-clamp-1 max-w-32 rounded-full px-2 text-center text-xs leading-relaxed",
-						tinycolor(notification.issue?.status.color).getLuminance() < 0.5
+						tinycolor(statusColor).getLuminance() < 0.5
 							? "text-white"
 							: "text-black",
 					)}
-					style={{ backgroundColor: notification.issue?.status.color }}
+					style={{ backgroundColor: statusColor }}
 				>
-					{notification.issue?.status.name}
+					{statusName}
 				</p>
 			</div>
 		</div>

--- a/components/NotificationItem/index.tsx
+++ b/components/NotificationItem/index.tsx
@@ -33,7 +33,6 @@ const getReasonText = (reason: number): [string, string, string] => {
 };
 
 type Props = {
-	alreadyRead: boolean;
 	reason: number;
 	projectKey: string;
 	issueKey: string;
@@ -41,13 +40,11 @@ type Props = {
 	statusName: string;
 	statusColor: string;
 	commentContent: string | undefined;
-	senderUserId: string;
 	senderName: string;
 	created: string;
 };
 
 export const NotificationItem: React.FC<Props> = ({
-	alreadyRead,
 	reason,
 	projectKey,
 	issueKey,
@@ -55,7 +52,6 @@ export const NotificationItem: React.FC<Props> = ({
 	statusName,
 	statusColor,
 	commentContent,
-	senderUserId,
 	senderName,
 	created,
 }) => {

--- a/components/ProjectItem/ProjectItem.stories.tsx
+++ b/components/ProjectItem/ProjectItem.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import type { Entity } from "backlog-js";
 import { ProjectItem } from "./index";
 
 /**
@@ -13,24 +12,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// 基本的なプロジェクトデータのモック
-const baseProject: Entity.Project.Project = {
-	archived: false,
-	chartEnabled: true,
-	displayOrder: 0,
-	id: 1,
+// 基本的なプロジェクトデータ
+const baseArgs = {
 	name: "サンプルプロジェクト",
 	projectKey: "SAMPLE",
-	projectLeaderCanEditProjectLeader: true,
-	subtaskingEnabled: true,
-	textFormattingRule: "markdown",
-	useDevAttributes: false,
 	useFileSharing: true,
 	useGit: false,
-	useResolvedForChart: true,
 	useSubversion: false,
 	useWiki: true,
-	useWikiTreeView: true,
 };
 
 /**
@@ -38,13 +27,11 @@ const baseProject: Entity.Project.Project = {
  */
 export const DefaultProject: Story = {
 	args: {
-		project: {
-			...baseProject,
-			useFileSharing: true,
-			useGit: true,
-			useSubversion: true,
-			useWiki: true,
-		},
+		...baseArgs,
+		useFileSharing: true,
+		useGit: true,
+		useSubversion: true,
+		useWiki: true,
 	},
 };
 
@@ -53,15 +40,13 @@ export const DefaultProject: Story = {
  */
 export const MinimalProject: Story = {
 	args: {
-		project: {
-			...baseProject,
-			name: "最小構成プロジェクト",
-			projectKey: "MIN",
-			useFileSharing: false,
-			useGit: false,
-			useSubversion: false,
-			useWiki: false,
-		},
+		...baseArgs,
+		name: "最小構成プロジェクト",
+		projectKey: "MIN",
+		useFileSharing: false,
+		useGit: false,
+		useSubversion: false,
+		useWiki: false,
 	},
 };
 
@@ -70,15 +55,13 @@ export const MinimalProject: Story = {
  */
 export const WikiEnabledProject: Story = {
 	args: {
-		project: {
-			...baseProject,
-			name: "Wiki使用プロジェクト",
-			projectKey: "WIKI",
-			useFileSharing: false,
-			useGit: false,
-			useSubversion: false,
-			useWiki: true,
-		},
+		...baseArgs,
+		name: "Wiki使用プロジェクト",
+		projectKey: "WIKI",
+		useFileSharing: false,
+		useGit: false,
+		useSubversion: false,
+		useWiki: true,
 	},
 };
 
@@ -87,15 +70,13 @@ export const WikiEnabledProject: Story = {
  */
 export const FileSharingEnabledProject: Story = {
 	args: {
-		project: {
-			...baseProject,
-			name: "ファイル共有プロジェクト",
-			projectKey: "FILE",
-			useFileSharing: true,
-			useGit: false,
-			useSubversion: false,
-			useWiki: false,
-		},
+		...baseArgs,
+		name: "ファイル共有プロジェクト",
+		projectKey: "FILE",
+		useFileSharing: true,
+		useGit: false,
+		useSubversion: false,
+		useWiki: false,
 	},
 };
 
@@ -104,15 +85,13 @@ export const FileSharingEnabledProject: Story = {
  */
 export const GitEnabledProject: Story = {
 	args: {
-		project: {
-			...baseProject,
-			name: "Git使用プロジェクト",
-			projectKey: "GIT",
-			useFileSharing: false,
-			useGit: true,
-			useSubversion: false,
-			useWiki: false,
-		},
+		...baseArgs,
+		name: "Git使用プロジェクト",
+		projectKey: "GIT",
+		useFileSharing: false,
+		useGit: true,
+		useSubversion: false,
+		useWiki: false,
 	},
 };
 
@@ -121,15 +100,13 @@ export const GitEnabledProject: Story = {
  */
 export const SubversionEnabledProject: Story = {
 	args: {
-		project: {
-			...baseProject,
-			name: "SVN使用プロジェクト",
-			projectKey: "SVN",
-			useFileSharing: false,
-			useGit: false,
-			useSubversion: true,
-			useWiki: false,
-		},
+		...baseArgs,
+		name: "SVN使用プロジェクト",
+		projectKey: "SVN",
+		useFileSharing: false,
+		useGit: false,
+		useSubversion: true,
+		useWiki: false,
 	},
 };
 
@@ -138,15 +115,13 @@ export const SubversionEnabledProject: Story = {
  */
 export const LongNameProject: Story = {
 	args: {
-		project: {
-			...baseProject,
-			name: "非常に長いプロジェクト名を持つプロジェクトのサンプルケース",
-			projectKey: "LONG_NAME_PROJ",
-			useFileSharing: true,
-			useGit: true,
-			useSubversion: false,
-			useWiki: true,
-		},
+		...baseArgs,
+		name: "非常に長いプロジェクト名を持つプロジェクトのサンプルケース",
+		projectKey: "LONG_NAME_PROJ",
+		useFileSharing: true,
+		useGit: true,
+		useSubversion: false,
+		useWiki: true,
 	},
 };
 
@@ -155,15 +130,12 @@ export const LongNameProject: Story = {
  */
 export const ArchivedProject: Story = {
 	args: {
-		project: {
-			...baseProject,
-			archived: true,
-			name: "アーカイブ済みプロジェクト",
-			projectKey: "ARCH",
-			useFileSharing: true,
-			useGit: false,
-			useSubversion: false,
-			useWiki: true,
-		},
+		...baseArgs,
+		name: "アーカイブ済みプロジェクト",
+		projectKey: "ARCH",
+		useFileSharing: true,
+		useGit: false,
+		useSubversion: false,
+		useWiki: true,
 	},
 };

--- a/components/ProjectItem/index.tsx
+++ b/components/ProjectItem/index.tsx
@@ -1,21 +1,31 @@
-import type { Entity } from "backlog-js";
-
 type Props = {
-	project: Entity.Project.Project;
+	projectKey: string;
+	name: string;
+	useWiki: boolean;
+	useFileSharing: boolean;
+	useSubversion: boolean;
+	useGit: boolean;
 };
 
-export const ProjectItem: React.FC<Props> = ({ project }) => {
+export const ProjectItem: React.FC<Props> = ({
+	projectKey,
+	name,
+	useWiki,
+	useFileSharing,
+	useSubversion,
+	useGit,
+}) => {
 	const navItems = [
 		{ action: "add", enabled: true, label: "課題の追加" },
 		{ action: "find", enabled: true, label: "課題" },
-		{ action: "wiki", enabled: project.useWiki, label: "Wiki" },
-		{ action: "file", enabled: project.useFileSharing, label: "ファイル" },
+		{ action: "wiki", enabled: useWiki, label: "Wiki" },
+		{ action: "file", enabled: useFileSharing, label: "ファイル" },
 		{
 			action: "subversion",
-			enabled: project.useSubversion,
+			enabled: useSubversion,
 			label: "Subversion",
 		},
-		{ action: "git", enabled: project.useGit, label: "Git" },
+		{ action: "git", enabled: useGit, label: "Git" },
 	].filter(({ enabled }) => enabled);
 
 	return (
@@ -29,8 +39,8 @@ export const ProjectItem: React.FC<Props> = ({ project }) => {
 				src="https://placehold.jp/320x320.png"
 			/>
 			<span className="flex items-end gap-1 self-center px-3 text-sm leading-none">
-				<span className="line-clamp-1">{project.name}</span>
-				<span className="text-2xs">({project.projectKey})</span>
+				<span className="line-clamp-1">{name}</span>
+				<span className="text-2xs">({projectKey})</span>
 			</span>
 			<span className="col-start-2 flex flex-wrap">
 				{navItems.map(({ action, label }) => (


### PR DESCRIPTION
## Summary
- NotificationItemコンポーネントのProps型定義と実装を統一
- ProjectItemコンポーネントのProps型定義と実装を統一
- 各コンポーネントのStoryファイルを新しいProps構造に更新

## 変更内容
- NotificationItemコンポーネント: notification オブジェクトではなく個別のpropsを受け取るよう修正
- ProjectItemコンポーネント: project オブジェクトではなく個別のpropsを受け取るよう修正
- 両コンポーネントのStoryファイルを簡潔な baseArgs パターンに更新
- 未使用パラメータを削除してlinter警告を解消

🤖 Generated with [Claude Code](https://claude.ai/code)